### PR TITLE
Improve assets and pause behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Turtle Trouble
+
+A retro-style platformer starring a turtle hero. Collect coins, avoid enemies, and defeat the boss.
+
+## Running the Game
+
+This project is completely client side. To play the game locally you need to serve the files over HTTP so that audio assets load correctly.
+
+1. Navigate to the project directory.
+2. Start a simple web server, for example using Python:
+   
+   ```bash
+   python3 -m http.server 8000
+   ```
+
+3. Open your browser and go to `http://localhost:8000`.
+
+## Controls
+
+- **A/D**: Move left and right
+- **W** or **Space**: Jump
+- **B**: Punch
+- **Shift**: Sprint
+- **Pause Button**: Pause/Resume the game
+
+Enjoy the adventure!

--- a/game.js
+++ b/game.js
@@ -33,7 +33,10 @@ const imageSources = {
     ground: 'assets/images/ground.png',
     platform: 'assets/images/platform.png',
     coinIcon: 'assets/images/coin-icon.png',
-    lifeIcon: 'assets/images/life-icon.png'
+    lifeIcon: 'assets/images/life-icon.png',
+    boss: 'assets/images/boss.png',
+    bossWalk1: 'assets/images/boss-walk1.png',
+    bossWalk2: 'assets/images/boss-walk2.png'
 };
 
 const loadImages = () => {
@@ -81,7 +84,16 @@ let paused = false;
 
 document.getElementById('pauseButton').addEventListener('click', () => {
     paused = !paused;
-    document.getElementById('pauseButton').textContent = paused ? 'Resume' : 'Pause';
+    const btn = document.getElementById('pauseButton');
+    btn.textContent = paused ? 'Resume' : 'Pause';
+
+    if (paused) {
+        if (sounds.background) sounds.background.pause();
+    } else {
+        lastTime = performance.now();
+        if (isMusicOn && sounds.background) sounds.background.play();
+        requestAnimationFrame(gameLoop);
+    }
 });
 
 // Handle user input
@@ -555,11 +567,11 @@ class Boss {
         if (!this.alive) return;
 
         let img;
-        // Animate boss in all states where it moves
+        // Animate boss using dedicated sprites
         if (this.state === 'chasing' || this.state === 'runningAway' || this.state === 'entering') {
-            img = this.animationFrame === 0 ? images.enemyWalk1 : images.enemyWalk2;
+            img = this.animationFrame === 0 ? images.bossWalk1 : images.bossWalk2;
         } else {
-            img = images.enemy;
+            img = images.boss;
         }
 
         ctx.save();


### PR DESCRIPTION
## Summary
- document how to run Turtle Trouble locally
- use dedicated boss images
- pause/resume the game loop correctly
- stop and resume music when pausing

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68510267414083268f8b025c502278db